### PR TITLE
Add JAVA_HOME environment variable to release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,7 @@ jobs:
               env:
                   SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
                   SLACK_USERNAME: ${{ secrets.SLACK_USERNAME }}
+                  JAVA_HOME: /usr/lib/jvm/default-jvm
             - name: Ballerina Push
               uses: ballerina-platform/ballerina-action/@master
               with:


### PR DESCRIPTION
## Purpose
Github workflow for the release.yml failed because the JAVA_HOME environment variable was not explicitly defined. This PR add this JAVA_HOME environment variable to release.yml.

## Goals
> Pass the release workflow and release the connector.

## Approach
> Add JAVA_HOME environment variable to release.yml.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
> JDK 11
> Ballerina SL Alpha 4
 
