### PR TITLE
Map slack listener events with proper record types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,5 @@ test.yml
 
 # Ignore Gradle build output directory
 build
+
+slack/tests/Config.toml

--- a/samples/listener/onAppMention.bal
+++ b/samples/listener/onAppMention.bal
@@ -25,7 +25,7 @@ slack:ListenerConfiguration configuration = {
 listener slack:Listener slackListener = new (configuration);
 
 service /slack on slackListener {
-    isolated remote function onAppMention(slack:SlackEvent eventInfo) returns error? {
+    isolated remote function onAppMention(slack:AppMentionEvent eventInfo) returns error? {
         log:printInfo("App Mentioned");
         log:printInfo(eventInfo.toString());
     }

--- a/samples/listener/onChannelCreated.bal
+++ b/samples/listener/onChannelCreated.bal
@@ -25,7 +25,7 @@ slack:ListenerConfiguration configuration = {
 listener slack:Listener slackListener = new (configuration);
 
 service /slack on slackListener {
-    isolated remote function onChannelCreated(slack:SlackEvent eventInfo) returns error? {
+    isolated remote function onChannelCreated(slack:ChannelCreatedEvent eventInfo) returns error? {
         log:printInfo("A Channel was created");
         log:printInfo(eventInfo.toString());
     }

--- a/samples/listener/onEmojiChanged.bal
+++ b/samples/listener/onEmojiChanged.bal
@@ -25,7 +25,7 @@ slack:ListenerConfiguration configuration = {
 listener slack:Listener slackListener = new (configuration);
 
 service /slack on slackListener {
-    isolated remote function onEmojiChanged(slack:SlackEvent eventInfo) returns error? {
+    isolated remote function onEmojiChanged(slack:EmojiChangedEvent eventInfo) returns error? {
         log:printInfo("A custom emoji has been added or changed");
         log:printInfo(eventInfo.toString());
     }

--- a/samples/listener/onFileShared.bal
+++ b/samples/listener/onFileShared.bal
@@ -1,0 +1,32 @@
+// Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/log;
+import ballerinax/slack.'listener as slack;
+
+slack:ListenerConfiguration configuration = {
+    port: 9090,
+    verificationToken: "VERIFICATION_TOKEN"
+};
+
+listener slack:Listener slackListener = new (configuration);
+
+service /slack on slackListener {
+    isolated remote function onFileShared(slack:FileSharedEvent eventInfo) returns error? {
+        log:printInfo("A file was shared");
+        log:printInfo(eventInfo.toString());
+    }
+}

--- a/samples/listener/onMemberJoinedChannel.bal
+++ b/samples/listener/onMemberJoinedChannel.bal
@@ -25,7 +25,7 @@ slack:ListenerConfiguration configuration = {
 listener slack:Listener slackListener = new (configuration);
 
 service /slack on slackListener {
-    isolated remote function onMemberJoinedChannel(slack:SlackEvent eventInfo) returns error? {
+    isolated remote function onMemberJoinedChannel(slack:MemberJoinedChannelEvent eventInfo) returns error? {
         log:printInfo("A user joined a public or private channel");
         log:printInfo(eventInfo.toString());
     }

--- a/samples/listener/onMessage.bal
+++ b/samples/listener/onMessage.bal
@@ -25,7 +25,7 @@ slack:ListenerConfiguration configuration = {
 listener slack:Listener slackListener = new (configuration);
 
 service /slack on slackListener {
-    isolated remote function onMessage(slack:SlackEvent eventInfo) returns error? {
+    isolated remote function onMessage(slack:MessageEvent eventInfo) returns error? {
         log:printInfo("New Message");
         log:printInfo(eventInfo.toString());
     }

--- a/samples/listener/onReactionAdded.bal
+++ b/samples/listener/onReactionAdded.bal
@@ -25,7 +25,7 @@ slack:ListenerConfiguration configuration = {
 listener slack:Listener slackListener = new (configuration);
 
 service /slack on slackListener {
-    isolated remote function onReactionAdded(slack:SlackEvent eventInfo) returns error? {
+    isolated remote function onReactionAdded(slack:ReactionAddedEvent eventInfo) returns error? {
         log:printInfo("A member has added an emoji reaction to an item");
         log:printInfo(eventInfo.toString());
     }

--- a/samples/listener/onTeamJoin.bal
+++ b/samples/listener/onTeamJoin.bal
@@ -25,7 +25,7 @@ slack:ListenerConfiguration configuration = {
 listener slack:Listener slackListener = new (configuration);
 
 service /slack on slackListener {
-    isolated remote function onTeamJoin(slack:SlackEvent eventInfo) returns error? {
+    isolated remote function onTeamJoin(slack:TeamJoinEvent eventInfo) returns error? {
         log:printInfo("A new member has joined");
         log:printInfo(eventInfo.toString());
     }

--- a/slack/Dependencies.toml
+++ b/slack/Dependencies.toml
@@ -5,11 +5,6 @@ version = "1.1.0-alpha8"
 
 [[dependency]]
 org = "ballerina"
-name = "test"
-version = "0.0.0"
-
-[[dependency]]
-org = "ballerina"
 name = "http"
 version = "1.1.0-alpha8"
 
@@ -37,3 +32,5 @@ version = "1.1.0-alpha8"
 org = "ballerina"
 name = "time"
 version = "2.0.0-alpha9"
+
+

--- a/slack/modules/listener/http_service.bal
+++ b/slack/modules/listener/http_service.bal
@@ -76,7 +76,6 @@ service class HttpService {
     # + return - Error if it is a failure
     isolated resource function post events (http:Caller caller, http:Request request) returns @tainted error? {
         json payload = check request.getJsonPayload();
-        SlackEvent slackEvent = {"event": payload};
         string eventOrVerification = check payload.'type;
 
         if (payload.token !== self.verificationToken) {
@@ -95,20 +94,28 @@ service class HttpService {
 
             // Handle the events based on the category of the event.
             if (eventType.startsWith("app_")) {
+                AppMentionEvent slackEvent = check payload.cloneWithType(AppMentionEvent);
                 check self.handleAppEvents(eventType, slackEvent);
             } else if (eventType.startsWith("channel_")) {
+                ChannelCreatedEvent slackEvent = check payload.cloneWithType(ChannelCreatedEvent);
                 check self.handleChannelEvents(eventType, slackEvent);
             } else if (eventType.startsWith("emoji_")) {
+                EmojiChangedEvent slackEvent = check payload.cloneWithType(EmojiChangedEvent);
                 check self.handleEmojiEvents(eventType, slackEvent);
             } else if (eventType.startsWith("file_")) {
+                FileSharedEvent slackEvent = check payload.cloneWithType(FileSharedEvent);
                 check self.handleFileEvents(eventType, slackEvent);
             } else if (eventType.startsWith("member_")) {
+                MemberJoinedChannelEvent slackEvent = check payload.cloneWithType(MemberJoinedChannelEvent);
                 check self.handleMemberEvents(eventType, slackEvent);
             } else if (eventType == "message") {
+                MessageEvent slackEvent = check payload.cloneWithType(MessageEvent);
                 check callOnMessage(self.httpService, slackEvent);
             } else if (eventType.startsWith("reaction_")) {
+                ReactionAddedEvent slackEvent = check payload.cloneWithType(ReactionAddedEvent);
                 check self.handleReactionEvents(eventType, slackEvent);
             } else if (eventType.startsWith("team_")) {
+                TeamJoinEvent slackEvent = check payload.cloneWithType(TeamJoinEvent);
                 check self.handleTeamEvents(eventType, slackEvent);
             }
         } else {
@@ -121,7 +128,7 @@ service class HttpService {
     # + eventType - Type of the Slack event
     # + slackEvent - Slack event record
     # + return - Error if it is a failure
-    isolated function handleAppEvents(string eventType, SlackEvent slackEvent) returns error? {
+    isolated function handleAppEvents(string eventType, AppMentionEvent slackEvent) returns error? {
         if (self.isOnAppMentionAvailable && eventType == "app_mention") {
             check callOnAppMention(self.httpService, slackEvent);
         }
@@ -132,7 +139,7 @@ service class HttpService {
     # + eventType - Type of the Slack event
     # + slackEvent - Slack event record
     # + return - Error if it is a failure
-    isolated function handleChannelEvents(string eventType, SlackEvent slackEvent) returns error? {
+    isolated function handleChannelEvents(string eventType, ChannelCreatedEvent slackEvent) returns error? {
         if (self.isOnChannelCreatedAvailable && eventType == "channel_created") {
             check callOnChannelCreated(self.httpService, slackEvent);
         }
@@ -143,7 +150,7 @@ service class HttpService {
     # + eventType - Type of the Slack event
     # + slackEvent - Slack event record
     # + return - Error if it is a failure
-    isolated function handleEmojiEvents(string eventType, SlackEvent slackEvent) returns error? {
+    isolated function handleEmojiEvents(string eventType, EmojiChangedEvent slackEvent) returns error? {
         if (self.isOnEmojiChangedAvailable && eventType == "emoji_changed") {
             check callOnEmojiChanged(self.httpService, slackEvent);
         }
@@ -154,7 +161,7 @@ service class HttpService {
     # + eventType - Type of the Slack event
     # + slackEvent - Slack event record
     # + return - Error if it is a failure
-    isolated function handleFileEvents(string eventType, SlackEvent slackEvent) returns error? {
+    isolated function handleFileEvents(string eventType, FileSharedEvent slackEvent) returns error? {
         if (self.isOnFileSharedAvailable && eventType == "file_shared") {
             check callOnFileShared(self.httpService, slackEvent);
         } 
@@ -165,7 +172,7 @@ service class HttpService {
     # + eventType - Type of the Slack event
     # + slackEvent - Slack event record
     # + return - Error if it is a failure
-    isolated function handleMemberEvents(string eventType, SlackEvent slackEvent) returns error? {
+    isolated function handleMemberEvents(string eventType, MemberJoinedChannelEvent slackEvent) returns error? {
         if (self.isOnMemberJoinedChannelAvailable && eventType == "member_joined_channel") {
             check callOnMemberJoinedChannel(self.httpService, slackEvent);
         }
@@ -176,7 +183,7 @@ service class HttpService {
     # + eventType - Type of the Slack event
     # + slackEvent - Slack event record
     # + return - Error if it is a failure
-    isolated function handleReactionEvents(string eventType, SlackEvent slackEvent) returns error? {
+    isolated function handleReactionEvents(string eventType, ReactionAddedEvent slackEvent) returns error? {
         if (self.isOnReactionAddedAvailable && eventType == "reaction_added") {
             check callOnReactionAdded(self.httpService, slackEvent);
         }
@@ -187,7 +194,7 @@ service class HttpService {
     # + eventType - Type of the Slack event
     # + slackEvent - Slack event record
     # + return - Error if it is a failure
-    isolated function handleTeamEvents(string eventType, SlackEvent slackEvent) returns error? {
+    isolated function handleTeamEvents(string eventType, TeamJoinEvent slackEvent) returns error? {
         if (self.isOnTeamJoinAvailable && eventType == "team_join") {
             check callOnTeamJoin(self.httpService, slackEvent);
         }

--- a/slack/modules/listener/natives.bal
+++ b/slack/modules/listener/natives.bal
@@ -22,7 +22,7 @@ isolated function callOnAppHomeOpened(SimpleHttpService httpService, SlackEvent 
     'class: "io.ballerinax.slack.HttpNativeOperationHandler"
 } external;
 
-isolated function callOnAppMention(SimpleHttpService httpService, SlackEvent event) returns error? 
+isolated function callOnAppMention(SimpleHttpService httpService, AppMentionEvent event) returns error? 
     = @java:Method {
     'class: "io.ballerinax.slack.HttpNativeOperationHandler"
 } external;
@@ -54,7 +54,7 @@ isolated function callOnChannelArchive(SimpleHttpService httpService, SlackEvent
     'class: "io.ballerinax.slack.HttpNativeOperationHandler"
 } external;
 
-isolated function callOnChannelCreated(SimpleHttpService httpService, SlackEvent event) returns error? 
+isolated function callOnChannelCreated(SimpleHttpService httpService, ChannelCreatedEvent event) returns error? 
     = @java:Method {
     'class: "io.ballerinax.slack.HttpNativeOperationHandler"
 } external;
@@ -107,7 +107,7 @@ isolated function callOnEmailDomainChanged(SimpleHttpService httpService, SlackE
 } external;
 
 // Emoji Events
-isolated function callOnEmojiChanged(SimpleHttpService httpService, SlackEvent event) returns error? 
+isolated function callOnEmojiChanged(SimpleHttpService httpService, EmojiChangedEvent event) returns error? 
     = @java:Method {
     'class: "io.ballerinax.slack.HttpNativeOperationHandler"
 } external;
@@ -148,7 +148,7 @@ isolated function callOnFilePublic(SimpleHttpService httpService, SlackEvent eve
     'class: "io.ballerinax.slack.HttpNativeOperationHandler"
 } external;
 
-isolated function callOnFileShared(SimpleHttpService httpService, SlackEvent event) returns error? 
+isolated function callOnFileShared(SimpleHttpService httpService, FileSharedEvent event) returns error? 
     = @java:Method {
     'class: "io.ballerinax.slack.HttpNativeOperationHandler"
 } external;
@@ -244,8 +244,8 @@ isolated function callOnLinkShared(SimpleHttpService httpService, SlackEvent eve
 } external;
 
 // Member Events
-isolated function callOnMemberJoinedChannel(SimpleHttpService httpService, SlackEvent event) returns error? 
-    = @java:Method {
+isolated function callOnMemberJoinedChannel(SimpleHttpService httpService, MemberJoinedChannelEvent event) 
+    returns error? = @java:Method {
     'class: "io.ballerinax.slack.HttpNativeOperationHandler"
 } external;
 
@@ -255,7 +255,7 @@ isolated function callOnMemberLeftChannel(SimpleHttpService httpService, SlackEv
 } external;
 
 // Message events
-isolated function callOnMessage(SimpleHttpService httpService, SlackEvent event) returns error? 
+isolated function callOnMessage(SimpleHttpService httpService, MessageEvent event) returns error? 
     = @java:Method {
     'class: "io.ballerinax.slack.HttpNativeOperationHandler"
 } external;
@@ -272,7 +272,7 @@ isolated function callOnPinRemoved(SimpleHttpService httpService, SlackEvent eve
 } external;
 
 // Reaction Events
-isolated function callOnReactionAdded(SimpleHttpService httpService, SlackEvent event) returns error? 
+isolated function callOnReactionAdded(SimpleHttpService httpService, ReactionAddedEvent event) returns error? 
     = @java:Method {
     'class: "io.ballerinax.slack.HttpNativeOperationHandler"
 } external;
@@ -357,7 +357,7 @@ isolated function callOnTeamDomainChange(SimpleHttpService httpService, SlackEve
     'class: "io.ballerinax.slack.HttpNativeOperationHandler"
 } external;
 
-isolated function callOnTeamJoin(SimpleHttpService httpService, SlackEvent event) returns error? 
+isolated function callOnTeamJoin(SimpleHttpService httpService, TeamJoinEvent event) returns error? 
     = @java:Method {
     'class: "io.ballerinax.slack.HttpNativeOperationHandler"
 } external;

--- a/slack/modules/listener/types.bal
+++ b/slack/modules/listener/types.bal
@@ -16,9 +16,381 @@
 
 # Slack Event information.
 #
-# + event - Event received from Slack
+# + token - A verification token to validate the event originated from Slack
+# + team_id - The unique identifier of the workspace where the event occurred
+# + api_app_id - The unique identifier your installed Slack application. Use this to distinguish which app the event 
+#                belongs to if you use multiple apps with the same Request URL.
+# + event - Contains the inner set of fields representing the actual event, that happened
+# + 'type - Indicates which kind of event dispatch this is, usually `event_callback`
+# + event_id - A unique identifier for this specific event, globally unique across all workspaces
+# + event_time - The epoch timestamp in seconds indicating when this event was dispatched
+# + event_context - Information about the event context 
+# + authorizations - Describes one of the installations that this event is visible to
 public type SlackEvent record { 
-    json event;
+    string token;
+    string team_id;
+    string api_app_id;
+    EventType event;
+    string 'type;
+    string event_id;
+    int event_time;
+    string event_context?;
+    json authorizations?;
+};
+
+# The inner set of fields representing the actual slack event, that happened.
+#
+# + 'type - The specific name of the event
+public type EventType record {
+    string 'type;
+};
+
+# Slack Event that mention your app or bot information.
+#
+# + token - A verification token to validate the event originated from Slack
+# + team_id - The unique identifier of the workspace where the event occurred
+# + api_app_id - The unique identifier your installed Slack application. Use this to distinguish which app the event 
+#                belongs to if you use multiple apps with the same Request URL.
+# + event - Contains the inner set of fields representing the actual event, that happened
+# + 'type - Indicates which kind of event dispatch this is, usually `event_callback`
+# + event_id - A unique identifier for this specific event, globally unique across all workspaces
+# + event_time - The epoch timestamp in seconds indicating when this event was dispatched
+# + event_context - Information about the event context 
+# + authorizations - Describes one of the installations that this event is visible to 
+public type AppMentionEvent record { 
+    string token;
+    string team_id;
+    string api_app_id;
+    AppMentionEventType event;
+    string 'type;
+    string event_id;
+    int event_time;
+    string event_context?;
+    json authorizations?;
+};
+
+# The inner set of fields representing the actual slack event that mention your app or bot.
+#
+# + 'type - Indicates which kind of event dispatch this 
+# + channel - The channel that mention your app or bot
+# + user - The user who mention your app or bot
+# + text - The mentioned text
+# + ts - The timestamp of what the event describes, which may occur slightly prior to the event being dispatched
+# + event_ts - The timestamp the event was dispatched 
+public type AppMentionEventType record {
+    string 'type;
+    string channel?;
+    string user?;
+    string text?;
+    string ts?;
+    string event_ts?;
+};
+
+# Slack Event with channel created information.
+#
+# + token - A verification token to validate the event originated from Slack
+# + team_id - The unique identifier of the workspace where the event occurred
+# + api_app_id - The unique identifier your installed Slack application. Use this to distinguish which app the event 
+#                belongs to if you use multiple apps with the same Request URL.
+# + event - Contains the inner set of fields representing the actual event, that happened
+# + 'type - Indicates which kind of event dispatch this is, usually `event_callback`
+# + event_id - A unique identifier for this specific event, globally unique across all workspaces
+# + event_time - The epoch timestamp in seconds indicating when this event was dispatched
+# + event_context - Information about the event context 
+# + authorizations - Describes one of the installations that this event is visible to  
+public type ChannelCreatedEvent record { 
+    string token;
+    string team_id;
+    string api_app_id;
+    ChannelCreatedEventType event;
+    string 'type;
+    string event_id;
+    int event_time;
+    string event_context?;
+    json authorizations?;
+};
+
+# The inner set of fields representing the actual slack event, that happened with channel created information.
+#
+# + 'type - Indicates which kind of event dispatch this 
+# + channel - The created channel
+public type ChannelCreatedEventType record {
+    string 'type;
+    Channel channel?;
+};
+
+# The created channel information.
+#
+# + id - Channel ID
+# + name - Channel name
+# + created - The epoch timestamp in seconds indicating when this channel was created
+# + creator - The creator of the channel
+public type Channel record {
+    string id;
+    string name?;
+    int created?;
+    string creator?;
+};
+
+# Slack Event with custom emoji added or changed information.
+#
+# + token - A verification token to validate the event originated from Slack
+# + team_id - The unique identifier of the workspace where the event occurred
+# + api_app_id - The unique identifier your installed Slack application. Use this to distinguish which app the event 
+#                belongs to if you use multiple apps with the same Request URL.
+# + event - Contains the inner set of fields representing the actual event, that happened
+# + 'type - Indicates which kind of event dispatch this is, usually `event_callback`
+# + event_id - A unique identifier for this specific event, globally unique across all workspaces
+# + event_time - The epoch timestamp in seconds indicating when this event was dispatched
+# + event_context - Information about the event context 
+# + authorizations - Describes one of the installations that this event is visible to 
+public type EmojiChangedEvent record { 
+    string token;
+    string team_id;
+    string api_app_id;
+    EmojiChangedEventType event;
+    string 'type;
+    string event_id;
+    int event_time;
+    string event_context?;
+    json authorizations?;
+};
+
+# The inner set of fields representing the actual slack event, that happened with custom emoji added or
+# changed information.
+#
+# + 'type - Field Description  
+# + subtype - Emoji changed subtype  
+# + event_ts - The timestamp the event was dispatched   
+# + name - Emoji name 
+# + value - Emoji value
+public type EmojiChangedEventType record {
+    string 'type;
+    string subtype?;
+    string event_ts?;
+    string name?;
+    string value?;
+};
+
+# Slack Event with file shared information.
+#
+# + token - A verification token to validate the event originated from Slack
+# + team_id - The unique identifier of the workspace where the event occurred
+# + api_app_id - The unique identifier your installed Slack application. Use this to distinguish which app the event 
+#                belongs to if you use multiple apps with the same Request URL.
+# + event - Contains the inner set of fields representing the actual event, that happened
+# + 'type - Indicates which kind of event dispatch this is, usually `event_callback`
+# + event_id - A unique identifier for this specific event, globally unique across all workspaces
+# + event_time - The epoch timestamp in seconds indicating when this event was dispatched
+# + event_context - Information about the event context 
+# + authorizations - Describes one of the installations that this event is visible to 
+public type FileSharedEvent record { 
+    string token;
+    string team_id;
+    string api_app_id;
+    FileSharedEventType event;
+    string 'type;
+    string event_id;
+    int event_time;
+    string event_context?;
+    json authorizations?;
+};
+
+# The inner set of fields representing the actual slack event, that happened with file shared information.
+#
+# + 'type - Indicates which kind of event dispatch this  
+# + channel_id - Channel ID the file was shared
+# + file_id - ID of the file shared 
+# + user_id - ID of the user who shared the file
+# + file - The shared file
+# + event_ts - The timestamp the event was dispatched 
+public type FileSharedEventType record {
+    string 'type;
+    string channel_id?;
+    string file_id?;
+    string user_id?;
+    File file?;
+    string event_ts?;
+};
+
+# The shared file information
+#
+# + id - Shared file ID
+public type File record {
+    string id;
+};
+
+# Slack Event with member joined channel information.
+#
+# + token - A verification token to validate the event originated from Slack
+# + team_id - The unique identifier of the workspace where the event occurred
+# + api_app_id - The unique identifier your installed Slack application. Use this to distinguish which app the event 
+#                belongs to if you use multiple apps with the same Request URL.
+# + event - Contains the inner set of fields representing the actual event, that happened
+# + 'type - Indicates which kind of event dispatch this is, usually `event_callback`
+# + event_id - A unique identifier for this specific event, globally unique across all workspaces
+# + event_time - The epoch timestamp in seconds indicating when this event was dispatched
+# + event_context - Information about the event context 
+# + authorizations - Describes one of the installations that this event is visible to 
+public type MemberJoinedChannelEvent record { 
+    string token;
+    string team_id;
+    string api_app_id;
+    MemberJoinedChannelEventType event;
+    string 'type;
+    string event_id;
+    int event_time;
+    string event_context?;
+    json authorizations?;
+};
+
+# The inner set of fields representing the actual slack event, that happened with member joined channel information.
+#
+# + 'type - Field Description  
+# + user - User ID belonging to the user that joined the channel  
+# + channel - ID of the channel joined  
+# + channel_type - single letter indicating the type of channel used in "channel"  
+# + team - The workspace the user is from  
+# + inviter - User ID of the inviting user  
+# + event_ts - The timestamp the event was dispatched 
+public type MemberJoinedChannelEventType record {
+    string 'type;
+    string user?;
+    string channel?;
+    string channel_type?;
+    string team?;
+    string inviter?;
+    string event_ts?;
+};
+
+# Slack Event with message sent information.
+#
+# + token - A verification token to validate the event originated from Slack
+# + team_id - The unique identifier of the workspace where the event occurred
+# + api_app_id - The unique identifier your installed Slack application. Use this to distinguish which app the event 
+#                belongs to if you use multiple apps with the same Request URL.
+# + event - Contains the inner set of fields representing the actual event, that happened
+# + 'type - Indicates which kind of event dispatch this is, usually `event_callback`
+# + event_id - A unique identifier for this specific event, globally unique across all workspaces
+# + event_time - The epoch timestamp in seconds indicating when this event was dispatched
+# + event_context - Information about the event context 
+# + authorizations - Describes one of the installations that this event is visible to 
+public type MessageEvent record { 
+    string token;
+    string team_id;
+    string api_app_id;
+    MessageEventType event;
+    string 'type;
+    string event_id;
+    int event_time;
+    string event_context?;
+    json authorizations?;
+};
+
+# The inner set of fields representing the actual slack event, that happened with message sent information.
+#
+# + 'type - Indicates which kind of event dispatch this 
+# + channel - The channel the message was sent
+# + channel_type - The channel type of the message
+# + user - The user who sent the message
+# + text - The message text
+# + ts - The timestamp of what the event describes, which may occur slightly prior to the event being dispatched
+# + event_ts - The timestamp the event was dispatched
+public type MessageEventType record {
+    string 'type;
+    string channel?;
+    string channel_type?;
+    string user?;
+    string text?;
+    string ts?;
+    string event_ts?;
+};
+
+# Slack Event with reaction added information.
+#
+# + token - A verification token to validate the event originated from Slack
+# + team_id - The unique identifier of the workspace where the event occurred
+# + api_app_id - The unique identifier your installed Slack application. Use this to distinguish which app the event 
+#                belongs to if you use multiple apps with the same Request URL.
+# + event - Contains the inner set of fields representing the actual event, that happened
+# + 'type - Indicates which kind of event dispatch this is, usually `event_callback`
+# + event_id - A unique identifier for this specific event, globally unique across all workspaces
+# + event_time - The epoch timestamp in seconds indicating when this event was dispatched
+# + event_context - Information about the event context 
+# + authorizations - Describes one of the installations that this event is visible to 
+public type ReactionAddedEvent record { 
+    string token;
+    string team_id;
+    string api_app_id;
+    ReactionAddedEventType event;
+    string 'type;
+    string event_id;
+    int event_time;
+    string event_context?;
+    json authorizations?;
+};
+
+# The inner set of fields representing the actual slack event, that happened with reaction added information.
+#
+# + 'type - Indicates which kind of event dispatch this 
+# + user - ID of the user who performed this event
+# + reaction - The reaction added
+# + item_user - ID of the user that created the original item that has been reacted to
+# + item - Brief reference to what was reacted to
+# + event_ts - The timestamp the event was dispatched
+public type ReactionAddedEventType record {
+    string 'type;
+    string user?;
+    string reaction?;
+    string item_user?;
+    Item item?;
+    string event_ts?;
+};
+
+# Brief reference to what was reacted to.
+#
+# + 'type - The type of the item reacted
+# + channel - The channel of the item reacted
+# + ts - The timestamp of reaction
+public type Item record {
+    string 'type?;
+    string channel?;
+    string ts?;
+};
+
+# Slack Event with new member team join information.
+#
+# + token - A verification token to validate the event originated from Slack
+# + team_id - The unique identifier of the workspace where the event occurred
+# + api_app_id - The unique identifier your installed Slack application. Use this to distinguish which app the event 
+#                belongs to if you use multiple apps with the same Request URL.
+# + event - Contains the inner set of fields representing the actual event, that happened
+# + 'type - Indicates which kind of event dispatch this is, usually `event_callback`
+# + event_id - A unique identifier for this specific event, globally unique across all workspaces
+# + event_time - The epoch timestamp in seconds indicating when this event was dispatched
+# + event_context - Information about the event context 
+# + authorizations - Describes one of the installations that this event is visible to 
+public type TeamJoinEvent record { 
+    string token;
+    string team_id;
+    string api_app_id;
+    TeamJoinEventType event;
+    string 'type;
+    string event_id;
+    int event_time;
+    string event_context?;
+    json authorizations?;
+};
+
+# The inner set of fields representing the actual slack event, that happened with new member team join information.
+#
+# + 'type - Indicates which kind of event dispatch this 
+# + user - User information of the team  
+# + event_ts - The timestamp the event was dispatched
+public type TeamJoinEventType record {
+    string 'type;
+    json user?;
+    string event_ts?;
 };
 
 # Listener configuration.


### PR DESCRIPTION
## Purpose
> `SlackEvent` record includes another json `event` as a field which is not mapped properly with the record type. Slack trigger gives a event record which includes another json as a field. User must give an effort to access the fields in the json.
https://github.com/ballerina-platform/module-ballerinax-slack/blob/250798ad91f0745f760eae0b0746b7883f411f26/slack/modules/listener/types.bal#L20

Resolves https://github.com/wso2-enterprise/choreo/issues/4087

## Goals
> Map slack listener events with proper record types & add missing sample for fileShared trigger

## Approach
> 

- Map slack listener events with proper record types
- Update listener event record type in samples 
- Add missing sample for fileShared trigger

## Release note
> For Slack v0.9.9

## Automation tests
 - Unit tests 
   > Done
 - Integration tests
   > Done

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> https://github.com/RolandHewage/module-ballerinax-slack/tree/slackEvent_record_fix/samples/listener

## Test environment
> 
Ubuntu 20.04
JDK 11
Swan Lake Alpha5

## Learning
> 
https://api.slack.com/apis/connections/events-api#the-events-api__receiving-events
https://api.slack.com/types/event
https://api.slack.com/events
https://api.slack.com/apps