### PR TITLE
Remove default values in Message record

### DIFF
--- a/slack/constants.bal
+++ b/slack/constants.bal
@@ -86,5 +86,3 @@ const string CURSOR = "&cursor=";
 const string INCLUSIVE = "&inclusive=true";
 const string TYPES = "types=";
 const string UTF8 = "UTF8";
-const string NONE = "none";
-const string FULL = "full";

--- a/slack/types.bal
+++ b/slack/types.bal
@@ -204,16 +204,22 @@ public type Message record {
     string iconImoji?;
     string iconUrl?;
     boolean linkNames?;
-    boolean mrkdwn = true;
-    Parse parse = NONE;
-    boolean replyBroadcast = false;
+    boolean mrkdwn?;
+    Parse parse?;
+    boolean replyBroadcast?;
     boolean unfurlLinks?;
     boolean unfurlMedia?;
     string username?;
 };
 
-# Refers how messages should be treated: `none`, which is the default value or `full` 
-public type Parse NONE|FULL;
+# Represents values for Parse
+# 
+# + NONE - none
+# + FULL - full
+public enum Parse {
+    NONE = "none",
+    FULL = "full"
+}
 
 # Holds the parameters used to create a `Client`.
 #


### PR DESCRIPTION
## Purpose
- Fix https://github.com/wso2-enterprise/choreo/issues/4476
- Fix https://github.com/wso2-enterprise/choreo/issues/4456

## Goals
> Remove default vales given in Message record type
> Make Parse as enum

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
> Ballerina SLBeta1
