### PR TITLE
Return HTTP OK Response after user logic execution

### DIFF
--- a/samples/listener/onMessage_HeavyProcessing.bal
+++ b/samples/listener/onMessage_HeavyProcessing.bal
@@ -1,0 +1,34 @@
+// Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerinax/slack.'listener as slack;
+
+slack:ListenerConfiguration configuration = {
+    port: 9090,
+    verificationToken: "VERIFICATION_TOKEN"
+};
+
+listener slack:Listener slackListener = new (configuration);
+
+service /slack on slackListener {
+    remote function onMessage(slack:MessageEvent eventInfo) returns error? {
+        _ = @strand { thread: "any" } start userLogic(eventInfo);
+    }
+}
+
+function userLogic(slack:MessageEvent eventInfo) returns error? {
+    // Write your logic here
+}

--- a/slack/modules/listener/Module.md
+++ b/slack/modules/listener/Module.md
@@ -95,5 +95,28 @@ service /slack on slackListener {
     }
 }
 ```
+> **NOTE:**
+If the user's logic inside any remote method of the connector listener throws an error, connector internal logic will 
+covert that error into a HTTP 500 error response and respond to the webhook (so that event may get redelivered), 
+otherwise it will respond with HTTP 200 OK. Due to this architecture, if the user logic in listener remote operations
+includes heavy processing, the user may face HTTP timeout issues for webhook responses. In such cases, it is advised to
+process events asynchronously as shown below.
+
+```ballerina
+import ballerinax/slack.'listener as slack;
+slack:ListenerConfiguration configuration = {
+    port: 9090,
+    verificationToken: "VERIFICATION_TOKEN"
+};
+listener slack:Listener slackListener = new (configuration);
+service /slack on slackListener {
+    remote function onMessage(slack:MessageEvent eventInfo) returns error? {
+        _ = @strand { thread: "any" } start userLogic(eventInfo);
+    }
+}
+function userLogic(slack:MessageEvent eventInfo) returns error? {
+    // Write your logic here
+}
+```
 
 ## Please check the [Samples directory](https://github.com/ballerina-platform/module-ballerinax-slack/tree/master/samples) for more examples.

--- a/slack/modules/listener/http_service.bal
+++ b/slack/modules/listener/http_service.bal
@@ -87,7 +87,6 @@ service class HttpService {
         } else if (eventOrVerification == EVENT_CALLBACK) {
             http:Response response = new;
             response.statusCode = http:STATUS_OK;
-            check caller->respond(response);
 
             json eventTypeJson = check payload.event.'type;
             string eventType = eventTypeJson.toString();
@@ -118,6 +117,7 @@ service class HttpService {
                 TeamJoinEvent slackEvent = check payload.cloneWithType(TeamJoinEvent);
                 check self.handleTeamEvents(eventType, slackEvent);
             }
+            check caller->respond(response);
         } else {
             return error("Unidentified Request Type");
         }


### PR DESCRIPTION
## Purpose
- Fix https://github.com/wso2-enterprise/choreo/issues/6342

Currently in the listener implementation, the moment we receive the event, we respond with status 200 OK, and then we dispatch the event. At user function implementation if there was an error we throw it up. In this case, as we have already responded with 200 OK, http client cannot convert the error and respond again, because it cannot respond to the same message twice.
Ideally we should respond with status 200 OK only after dispatching the event. At user function implementation if there was an error we throw it up & the http client will return status 500 error. If there is no any errors & the user logic is executed successfully, we should respond with status 200 OK.

## Goals
- Return HTTP OK Response after user logic execution

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Related PRs
https://github.com/ballerina-platform/module-ballerinax-slack/pull/45

## Test environment
JDK 11
Ballerina SLBeta2
