### PR TITLE
Bump ballerina version and fix connector version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 group=io.ballerinax.slack
 version=0.9.9
-ballerinaLangVersion=2.0.0-alpha8-20210423-135000-530658ec
+ballerinaLangVersion=2.0.0-beta.3

--- a/slack/Ballerina.toml
+++ b/slack/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org= "ballerinax"
 name= "slack"
-version= "0.9.11"
+version= "0.9.10"
 export= ["slack", "slack.listener"]
 license= ["Apache-2.0"]
 authors = ["Ballerina"]


### PR DESCRIPTION
# Description
- Bump ballerinaLang version in gradle.properties to 2.0.0-beta.3
- Fix the connector version as 0.9.10 (latest version in prod central is 0.9.9)

### Security checks
 - [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? 
 - [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? 
