### PR TITLE
Bump jar version to 0.9.10 same as bal package

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 group=io.ballerinax.slack
-version=0.9.9
+version=0.9.10
 ballerinaLangVersion=2.0.0-beta.3

--- a/slack/Ballerina.toml
+++ b/slack/Ballerina.toml
@@ -9,7 +9,7 @@ keywords = ["slack"]
 repository = "https://github.com/ballerina-platform/module-ballerinax-slack"
 
 [[platform.java11.dependency]]
-path = "../java-wrapper/build/libs/java-wrapper-0.9.9.jar"
+path = "../java-wrapper/build/libs/java-wrapper-0.9.10.jar"
 groupId = "io.ballerinax.slack"
 artifactId = "java-wrapper"
-version = "0.9.9"
+version = "0.9.10"


### PR DESCRIPTION
# Description
Bump java component version to 0.9.10 same as ballerina package version mentioned in Ballerina.toml
 
### Security checks
 - [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? 
 - [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?