### PR TITLE
Add SLAlpha5 to SLBeta3 changes

### DIFF
--- a/slack/tests/main_test.bal
+++ b/slack/tests/main_test.bal
@@ -60,9 +60,11 @@ UpdateMessage updateMessageParams = {
 @test:Config {}
 function testGetConversationHistory() returns @tainted error? {
     stream<MessageInfo,error?>|error? resultStream = slackClient->getConversationHistory(channelName1);
-    if (resultStream is stream<MessageInfo,error>) {        
-        record {|MessageInfo value;|} res = check resultStream.next(); 
-        test:assertEquals(res.value.'type, "message");
+    if (resultStream is stream<MessageInfo,error?>) {        
+        record {|MessageInfo value;|}|error? res = check resultStream.next(); 
+        if (res is record {|MessageInfo value;|}) {
+            test:assertEquals(res.value.'type, "message");
+        }
     } else {
         test:assertFail("Error in getting stream");
     }
@@ -71,7 +73,7 @@ function testGetConversationHistory() returns @tainted error? {
 @test:Config {}
 function testGetConversationMembers() returns error? {
     stream<string,error?>|error? resultStream = slackClient->getConversationMembers(channelName1);
-    if (resultStream is stream<string,error>) {   
+    if (resultStream is stream<string,error?>) {   
         error? e = resultStream.forEach(isolated function (string memberId) {});
         if (e is error) {
             test:assertFail(e.message());

--- a/slack/utils.bal
+++ b/slack/utils.bal
@@ -125,7 +125,7 @@ isolated function getConversationInfo(http:Client slackClient, string channelId,
                                       boolean? memberCount = false) returns @tainted Channel|error {
     string url = GET_CONVERSATION_INFO_PATH + channelId + INCLUDE_LOCALE + includeLocale.toString() + 
                     INCLUDE_NUM_MEMBERS + memberCount.toString();
-    http:Response|http:PayloadType|error response = slackClient->get(url);
+    http:Response|error response = slackClient->get(url);
     if (response is error) {
         return setResError(response);
     } else {


### PR DESCRIPTION
# Description
- Add SLAlpha5 to SLBeta3 changes
- This is to make 0.9.10 version of the connector compatible with SLBeta3

### Security checks
 - [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? 
 - [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? 
