### PR TITLE
Add missing `&` in constant TYPES

### DIFF
--- a/slack/constants.bal
+++ b/slack/constants.bal
@@ -84,5 +84,5 @@ const string LATEST = "&latest=";
 const string OLDEST = "&oldest=";
 const string CURSOR = "&cursor=";
 const string INCLUSIVE = "&inclusive=true";
-const string TYPES = "types=";
+const string TYPES = "&types=";
 const string UTF8 = "UTF8";


### PR DESCRIPTION
# Description
Add missing `&` in `TYPES` defined in constants.bal

### Security checks
 - [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? 
 - [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? 
