### PR TITLE
add `return`  to  explicitly return a value

### DIFF
--- a/slack/endpoint.bal
+++ b/slack/endpoint.bal
@@ -30,6 +30,7 @@ public isolated client class Client {
     # + config - Configuration required to initialize the `Client` endpoint
     public isolated function init(ConnectionConfig config) returns error? {
         self.slackClient =  check new (BASE_URL, config);
+        return;
     }
 
     private isolated function getChannelIdMap() returns map<string> {

--- a/slack/modules/listener/http_service.bal
+++ b/slack/modules/listener/http_service.bal
@@ -104,6 +104,7 @@ isolated service class HttpService {
         } else {
             return error("Unidentified Request Type");
         }
+        return;
     }
 
     # Handle App related events.
@@ -115,6 +116,7 @@ isolated service class HttpService {
         if (self.isOnAppMentionAvailable && eventType == "app_mention") {
             check self.adaptor.callOnAppMention(slackEvent);
         }
+        return;
     }
 
     # Handle Channel related events.
@@ -126,6 +128,7 @@ isolated service class HttpService {
         if (self.isOnChannelCreatedAvailable && eventType == "channel_created") {
             check self.adaptor.callOnChannelCreated(slackEvent);
         }
+        return;
     }
 
     # Handle Emoji related events.
@@ -137,6 +140,7 @@ isolated service class HttpService {
         if (self.isOnEmojiChangedAvailable && eventType == "emoji_changed") {
             check self.adaptor.callOnEmojiChanged(slackEvent);
         }
+        return;
     }
 
     # Handle File related events.
@@ -148,6 +152,7 @@ isolated service class HttpService {
         if (self.isOnFileSharedAvailable && eventType == "file_shared") {
             check self.adaptor.callOnFileShared(slackEvent);
         } 
+        return;
     }
 
     # Handle Member related events.
@@ -159,6 +164,7 @@ isolated service class HttpService {
         if (self.isOnMemberJoinedChannelAvailable && eventType == "member_joined_channel") {
             check self.adaptor.callOnMemberJoinedChannel(slackEvent);
         }
+        return;
     }
 
     # Handle Reaction related events.
@@ -170,6 +176,7 @@ isolated service class HttpService {
         if (self.isOnReactionAddedAvailable && eventType == "reaction_added") {
             check self.adaptor.callOnReactionAdded(slackEvent);
         }
+        return;
     }
 
     # Handle Team related events.
@@ -181,6 +188,7 @@ isolated service class HttpService {
         if (self.isOnTeamJoinAvailable && eventType == "team_join") {
             check self.adaptor.callOnTeamJoin(slackEvent);
         }
+        return;
     }
 
     # Respond to the URL verification request with the challenge in the payload.
@@ -194,6 +202,7 @@ isolated service class HttpService {
         response.setPayload({challenge: check <@untainted>payload.challenge});
         check caller->respond(response);
         log:printInfo("Request URL Verified");
+        return;
     }
 }
 

--- a/slack/modules/listener/listener.bal
+++ b/slack/modules/listener/listener.bal
@@ -33,12 +33,14 @@ public class Listener {
     public isolated function init(ListenerConfiguration config) returns error? {
         self.httpListener = check new (config.port);
         self.verificationToken = config.verificationToken;
+        return;
     }
 
     public isolated function attach(SimpleHttpService s, string[]|string? name = ()) returns @tainted error? {
         HttpToSlackAdaptor adaptor = check new (s);
         self.httpService = new HttpService(adaptor, self.verificationToken);
         check self.httpListener.attach(self.httpService, name);
+        return;
     }
 
     public isolated function detach(service object {} s) returns error? {

--- a/slack/modules/listener/natives.bal
+++ b/slack/modules/listener/natives.bal
@@ -19,6 +19,7 @@ import ballerina/jballerina.java;
 isolated class HttpToSlackAdaptor {
     isolated function init(SimpleHttpService serviceObj) returns error? {
         externInit(self, serviceObj);
+        return;
     }
 
     // App Events

--- a/slack/stream_implementer.bal
+++ b/slack/stream_implementer.bal
@@ -34,6 +34,7 @@ class ConversationHistoryStream {
         self.endOfTimeRange = endOfTimeRange;
         self.nextCursor = ();
         self.currentEntries =  check self.fetchMessages();
+        return;
     }
 
     public isolated function next() returns @tainted record {| MessageInfo value; |}|error? {
@@ -50,6 +51,7 @@ class ConversationHistoryStream {
             self.index += 1;
             return message;
         }
+        return;
     }
 
     isolated function fetchMessages() returns @tainted MessageInfo[]|error {
@@ -93,6 +95,7 @@ class ConversationMembersStream {
         self.channelId = channelId;
         self.nextCursor = ();
         self.currentEntries =  check self.fetchMembers();
+        return;
     }
 
     public isolated function next() returns @tainted record {| string value; |}|error? {
@@ -109,6 +112,7 @@ class ConversationMembersStream {
             self.index += 1;
             return member;
         }
+        return;
     }
 
     isolated function fetchMembers() returns @tainted string[]|error {

--- a/slack/tests/main_test.bal
+++ b/slack/tests/main_test.bal
@@ -68,6 +68,7 @@ function testGetConversationHistory() returns error? {
     } else {
         test:assertFail("Error in getting stream");
     }
+    return;
 }
 
 @test:Config {}
@@ -77,6 +78,7 @@ function testGetConversationMembers() returns error? {
     if (e is error) {
         test:assertFail(e.message());
     }
+    return;
 }
 
 @test:Config {dependsOn: [testGetConversationMembers]}

--- a/slack/utils.bal
+++ b/slack/utils.bal
@@ -48,7 +48,8 @@ isolated function unArchiveConversation(http:Client slackClient, string channelI
 isolated function handleArchiveResponse(http:Client slackClient, string url) returns @tainted error? {
     http:Response response = check slackClient->post(url, EMPTY_STRING);
     json payload = check response.getJsonPayload();
-    var checkOk = check checkOk(payload);       
+    var checkOk = check checkOk(payload);   
+    return;    
 }
 
 isolated function getUserIds(http:Client slackClient, string[] users) returns @tainted string|error {
@@ -280,6 +281,7 @@ isolated function checkOk(json respPayload) returns error? {
             return error(errorRes.toString());
         }
     }
+    return;
 }
 
 isolated function deleteMessage(http:Client slackClient, string channelId, string threadTs) returns @tainted error? {
@@ -408,6 +410,7 @@ isolated function handleOkResp(http:Client slackClient, string url) returns @tai
     http:Response response = check slackClient->post(url, EMPTY_STRING);
     json payload = check response.getJsonPayload();
     error? checkOkResp = checkOk(payload);
+    return;
 }
 
 isolated function setResError(error errorResponse) returns error {


### PR DESCRIPTION
# Description
This PR fixes this error 
```
WARNING [tests/main_test.bal:(61:47,61:53)] this function should explicitly return a value
WARNING [tests/main_test.bal:(74:47,74:53)] this function should explicitly return a value
WARNING [utils.bal:(48:95,48:101)] this function should explicitly return a value
WARNING [utils.bal:(272:53,272:59)] this function should explicitly return a value
WARNING [utils.bal:(407:86,407:92)] this function should explicitly return a value
```

**Test Configuration**:
* Ballerina Version: Ballerina swan lake beta 4
* Operating System: Ubuntu (Linux)
* Java SDK: Java 11

# Checklist:

### Security checks
 - [X] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? 
 - [X] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? 
