### PR TITLE
Fix daily build failure

### DIFF
--- a/slack/types.bal
+++ b/slack/types.bal
@@ -182,7 +182,7 @@ public type FileInfo record {
     string urlPrivate;
     string urlPrivateDownload;
     string permalink;
-    string permalinkPublic;
+    string permalinkPublic?;
     int lines;
     int linesMore;
     int commentsCount;


### PR DESCRIPTION
# Description

Daily build is failed due to a single test failure. It is an error occurred due to Ballerina type conversion error. In the response `permalinkPublic` is not there but in the conversion type it is denoted as mandatory. 

Fixes # (issue)

N/A

One line release note: 
- Fix daily build by updating types

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Ran tests and verified

**Test Configuration**:
* Ballerina Version: 

Ballerina 2201.2.3 (Swan Lake Update 2)
Language specification 2022R3

# Checklist:

### Security checks
 - [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? 
 - [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? 
