### PR TITLE
[2201.1.x] Update `FileInfo` record in types.bal`

### DIFF
--- a/slack/types.bal
+++ b/slack/types.bal
@@ -172,7 +172,7 @@ public type FileInfo record {
     string urlPrivate;
     string urlPrivateDownload;
     string permalink;
-    string permalinkPublic;
+    string permalinkPublic?;
     int lines;
     int linesMore;
     int commentsCount;


### PR DESCRIPTION
# Description
- Make `string permalinkPublic;` as `string permalinkPublic?;` in `FileInfo` record

Related Pull Requests (remove if not relevant)
- https://github.com/ballerina-platform/module-ballerinax-slack/pull/133
