### PR TITLE
Disable tests when publishing to dev/stage central

### DIFF
--- a/.github/workflows/dev-stg-release.yml
+++ b/.github/workflows/dev-stg-release.yml
@@ -19,3 +19,4 @@ jobs:
     secrets: inherit
     with:
       environment: ${{ github.event.inputs.environment }}
+      additional-publish-flags: "-x test" # temp workaround which must be removed once 2201.9.2 is released


### PR DESCRIPTION
This is done as an urgent workaround and must be removed once 2201.9.2 is released

## Examples

## Checklist
- [ ] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
- [ ] Updated the spec
- [ ] Checked native-image compatibility
